### PR TITLE
Add location endpoint for location partials

### DIFF
--- a/server/api/api.js
+++ b/server/api/api.js
@@ -4,10 +4,12 @@ const router = require('express').Router();
 const users = require('./users/userRoutes');
 const posts = require('./posts/postRoutes');
 const breweries = require('./breweries/breweryRoutes');
+const locations = require('./locations/locationRoutes');
 
 
 router.use('/users', users);
 router.use('/posts', posts);
 router.use('/breweries', breweries);
+router.use('/locations', locations);
 
 module.exports = router;

--- a/server/api/locations/locationController.js
+++ b/server/api/locations/locationController.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const axios = require('axios');
+
+// const Post = require('./postModel')
+const _API_KEY = require('../config/apiKeys.js').googleMapsAPIKey;
+const _API_BASEURL = 'https://maps.googleapis.com/maps/api/';
+
+
+exports.get = (req, res, next) => {
+
+  // Google Maps endpoint
+  var endPoint = 'place/autocomplete/json';
+
+  // endpoint query options
+  var queryOptions = {
+    
+    input: req.params.locationPartial,
+    types: '(cities)'
+  };
+
+  // axios RESTful API call
+  axios.get(createUrl(endPoint, queryOptions))
+  .then(function (response) {
+    res.end(JSON.stringify(response.data));
+  })
+  .catch(function (error) {
+    console.log(error);
+  });
+
+}
+
+exports.post = (req, res, next) => {
+  // console.log('brewery post controller');
+
+}
+
+// Helper formatting function for connecting to breweryDB 
+var createUrl = function(endPoint, queryOptions) {
+  var key = '?key=' + _API_KEY;
+
+  var queryStrings = [];
+
+  // Create query string from all query options
+  for (let query in queryOptions) {
+    if (typeof queryOptions[query] === 'string') {
+      // encode spaces for url if query option is string
+      queryStrings.push(query + '=' + queryOptions[query].replace(' ', '+'));
+    } else {
+      queryStrings.push(query + '=' + queryOptions[query]);
+    }
+  }
+
+  return _API_BASEURL + endPoint + key + '&' + queryStrings.join('&');
+}

--- a/server/api/locations/locationRoutes.js
+++ b/server/api/locations/locationRoutes.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const router = require('express').Router();
+const location = require('./locationController');
+
+router.route('/:locationPartial')
+  .get(location.get)
+  .post(location.post);
+
+module.exports = router;
+


### PR DESCRIPTION
Add location endpoint for location partials. This is needed for the autocomplete feature that lets users type partials and autocomplete with available cities. For example, a user can type 'sd', and autocomplete to 'San Diego'.